### PR TITLE
Fix work_complete packet magic

### DIFF
--- a/rustygear/src/client.rs
+++ b/rustygear/src/client.rs
@@ -220,7 +220,7 @@ impl WorkerJob {
         payload.extend(self.handle.clone());
         payload.put_u8(b'\0');
         payload.extend(response);
-        let packet = new_res(WORK_COMPLETE, payload.freeze());
+        let packet = new_req(WORK_COMPLETE, payload.freeze());
         self.send_packet(packet).await
     }
 }


### PR DESCRIPTION
according to [documentation](http://gearman.org/protocol/) worker packet magic for `WORK_COMPLETE` should be `\0REQ`, otherwise it throws `Request magic expected` (see https://github.com/gearman/gearmand/blob/302f33cebf730a9f7356ccdcc4cb8b4c171bd68a/libgearman-server/server.cc#L114) and job stays in queue