### PR TITLE
chore(cargo): update `homepage` to `repository`

### DIFF
--- a/rustygear/Cargo.toml
+++ b/rustygear/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustygear"
 description = "Client library for communicating via the gearman protocol"
-homepage = "https://github.com/SpamapS/rustygear"
+repository = "https://github.com/SpamapS/rustygear"
 version = "0.11.0"
 authors = ["Clint Byrum <clint@fewbar.com>"]
 license = "Apache-2.0"

--- a/rustygeard/Cargo.toml
+++ b/rustygeard/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Clint Byrum <clint@fewbar.com>"]
 license = "Apache-2.0"
 edition = "2018"
 keywords = ["gearman", "server"]
-homepage = "https://github.com/SpamapS/rustygear"
+repository = "https://github.com/SpamapS/rustygear"
 
 [dependencies]
 bytes = ">=1.1.0"


### PR DESCRIPTION
Change `homepage` key to instead use the [repository](https://rust-digger.code-maven.com/about-repository) key for correctly labeling/pointing to the GitHub repo.

This makes location of the source code easier to see Crates.io. 🙂